### PR TITLE
feat: add MCP registry publish workflow and server configuration

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,26 @@
+name: Publish to MCP Registry
+# https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/github-actions.md
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install MCP Publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Prepare private key
+        run: echo "${{ secrets.MCP_PUBLISH_PRIVATE_KEY }}" > key.pem
+
+      - name: Login to MCP Registry
+        run: ./mcp-publisher login dns --domain prisma.io --private-key $(openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -3,24 +3,66 @@ name: Publish to MCP Registry
 
 on:
   push:
-    branches: ["main"]
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+
+      - name: Validate server.json
+        run: |
+          # Basic JSON validation
+          if ! python3 -m json.tool server.json > /dev/null 2>&1; then
+            echo "❌ server.json is not valid JSON"
+            exit 1
+          fi
+          echo "✅ server.json is valid JSON"
+          
+          # Validate remote endpoints are accessible
+          echo "🔍 Validating remote endpoints..."
+          for url in $(python3 -c "import json; data=json.load(open('server.json')); [print(remote['url']) for remote in data.get('remotes', [])]"); do
+            if curl -s --head "$url" > /dev/null; then
+              echo "✅ Endpoint accessible: $url"
+            else
+              echo "⚠️  Endpoint may require authentication: $url"
+            fi
+          done
 
       - name: Install MCP Publisher
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
       - name: Prepare private key
+        if: env.MCP_PUBLISH_PRIVATE_KEY != ''
         run: echo "${{ secrets.MCP_PUBLISH_PRIVATE_KEY }}" > key.pem
+        env:
+          MCP_PUBLISH_PRIVATE_KEY: ${{ secrets.MCP_PUBLISH_PRIVATE_KEY }}
 
-      - name: Login to MCP Registry
+      - name: Login to MCP Registry (DNS)
+        if: env.MCP_PUBLISH_PRIVATE_KEY != ''
         run: ./mcp-publisher login dns --domain prisma.io --private-key $(openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')
+        env:
+          MCP_PUBLISH_PRIVATE_KEY: ${{ secrets.MCP_PUBLISH_PRIVATE_KEY }}
+
+      - name: Login to MCP Registry (GitHub OIDC)
+        if: env.MCP_PUBLISH_PRIVATE_KEY == ''
+        run: ./mcp-publisher login github-oidc
+        env:
+          MCP_PUBLISH_PRIVATE_KEY: ${{ secrets.MCP_PUBLISH_PRIVATE_KEY }}
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish
+
+      - name: Clean up private key
+        if: always() && env.MCP_PUBLISH_PRIVATE_KEY != ''
+        run: rm -f key.pem
+        env:
+          MCP_PUBLISH_PRIVATE_KEY: ${{ secrets.MCP_PUBLISH_PRIVATE_KEY }}

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,0 +1,266 @@
+# Publishing Prisma Remote MCP Server to Official Registry
+
+This guide provides step-by-step instructions for publishing the Prisma remote MCP server to the official Model Context Protocol (MCP) registry.
+
+## Overview
+
+This repository contains configuration for publishing Prisma's **remote MCP server** (hosted at `https://mcp.prisma.io/mcp`) to the official MCP registry. This is distinct from the local MCP server that's part of the Prisma ORM NPM package.
+
+### What Gets Published
+
+- **Remote MCP Server**: A cloud-hosted MCP server accessible at `https://mcp.prisma.io/mcp`
+- **Authentication Required**: Requires Bearer token authentication via Prisma platform
+- **Endpoints**: Both SSE (`/sse`) and streamable-http (`/mcp`) protocols supported
+
+## Prerequisites
+
+### 1. DNS Authentication Setup
+
+Since we're using the namespace `io.prisma/mcp`, we need DNS authentication for the `prisma.io` domain.
+
+**Required GitHub Secret:**
+- `MCP_PUBLISH_PRIVATE_KEY`: The private key for DNS authentication
+
+### 2. DNS TXT Record
+
+Ensure the following DNS TXT record is configured for `prisma.io`:
+
+```
+_mcp-publisher.prisma.io TXT "v=mcp1; pub-key=<PUBLIC_KEY>"
+```
+
+Where `<PUBLIC_KEY>` is the public key corresponding to the private key stored in GitHub secrets.
+
+## First-Time Setup
+
+### Step 1: Generate Key Pair (If Not Already Done)
+
+If you need to generate a new key pair for DNS authentication:
+
+```bash
+# Generate private key
+openssl genpkey -algorithm Ed25519 -out private-key.pem
+
+# Extract public key
+openssl pkey -in private-key.pem -pubout -outform DER | base64 -w 0
+```
+
+### Step 2: Configure DNS Record
+
+Add the TXT record to `prisma.io` DNS configuration:
+
+```
+_mcp-publisher.prisma.io TXT "v=mcp1; pub-key=<BASE64_PUBLIC_KEY>"
+```
+
+### Step 3: Add GitHub Secret
+
+1. Go to the repository settings: `https://github.com/prisma/mcp/settings/secrets/actions`
+2. Click "New repository secret"
+3. Name: `MCP_PUBLISH_PRIVATE_KEY`
+4. Value: The contents of your `private-key.pem` file (including `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----` lines)
+
+## Publishing Process
+
+### Automated Publishing (Recommended)
+
+The repository is configured with GitHub Actions for automated publishing:
+
+#### For New Versions:
+
+1. **Update Version**: Update the `version` field in `server.json`
+   ```json
+   {
+     "version": "1.0.1",
+     ...
+   }
+   ```
+
+2. **Commit Changes**:
+   ```bash
+   git add server.json
+   git commit -m "chore: bump version to 1.0.1"
+   git push origin main
+   ```
+
+3. **Create and Push Tag**:
+   ```bash
+   git tag v1.0.1
+   git push origin v1.0.1
+   ```
+
+4. **Monitor Workflow**: Check the Actions tab to monitor the publishing process
+
+#### For Manual Trigger:
+
+You can also trigger publishing manually from the GitHub Actions UI:
+
+1. Go to Actions tab in the repository
+2. Select "Publish to MCP Registry" workflow
+3. Click "Run workflow"
+4. Select the branch and click "Run workflow"
+
+### What the Workflow Does
+
+The automated workflow:
+
+1. ✅ **Validates** `server.json` syntax and structure
+2. 🔍 **Checks** remote endpoint accessibility 
+3. 📦 **Installs** MCP Publisher CLI
+4. 🔐 **Authenticates** using DNS method with private key
+5. 🚀 **Publishes** to the MCP registry
+6. 🧹 **Cleans up** temporary files securely
+
+### Manual Publishing (If Needed)
+
+If you need to publish manually:
+
+1. **Install MCP Publisher**:
+   ```bash
+   curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+   ```
+
+2. **Authenticate**:
+   ```bash
+   # Extract private key from GitHub secret or file
+   echo "$MCP_PUBLISH_PRIVATE_KEY" > key.pem
+   
+   # Login using DNS authentication
+   ./mcp-publisher login dns --domain prisma.io --private-key $(openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')
+   ```
+
+3. **Publish**:
+   ```bash
+   ./mcp-publisher publish
+   ```
+
+4. **Clean up**:
+   ```bash
+   rm -f key.pem
+   ```
+
+## Configuration Files
+
+### server.json
+
+The `server.json` file contains the metadata for the remote MCP server:
+
+```json
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
+  "name": "io.prisma/mcp",
+  "description": "MCP server for managing Prisma Postgres.",
+  "version": "1.0.0",
+  "remotes": [
+    {
+      "type": "sse",
+      "url": "https://mcp.prisma.io/sse",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer token for Prisma platform authentication",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    },
+    {
+      "type": "streamable-http", 
+      "url": "https://mcp.prisma.io/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer token for Prisma platform authentication", 
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Key Configuration Points:
+
+- **Namespace**: `io.prisma/mcp` (requires DNS authentication for `prisma.io`)
+- **Remote Endpoints**: Both SSE and streamable-http protocols
+- **Authentication**: Bearer token required for both endpoints
+- **URLs**: Point to the production Prisma platform MCP service
+
+## Troubleshooting
+
+### Common Issues
+
+#### 1. Authentication Failure
+```
+Error: DNS authentication failed
+```
+**Solution**: Verify that:
+- The TXT record is properly configured for `_mcp-publisher.prisma.io`
+- The private key in GitHub secrets matches the public key in DNS
+- DNS propagation is complete (may take up to 24 hours)
+
+#### 2. Invalid server.json
+```
+Error: Invalid server configuration
+```
+**Solution**: 
+- Validate JSON syntax using `python3 -m json.tool server.json`
+- Ensure all required fields are present
+- Check that URLs are accessible
+
+#### 3. Endpoint Validation Warnings
+```
+⚠️ Endpoint may require authentication: https://mcp.prisma.io/mcp
+```
+**This is expected** for authenticated endpoints. The workflow will continue normally.
+
+#### 4. Tag Already Exists
+```
+Error: tag already exists
+```
+**Solution**:
+- Use a new version number
+- Or delete the existing tag: `git tag -d v1.0.1 && git push origin :refs/tags/v1.0.1`
+
+### Verification
+
+After successful publishing, verify your server appears in the registry:
+
+1. Search for "prisma" in the [MCP Registry](https://github.com/modelcontextprotocol/registry)
+2. Check that the server metadata is correct
+3. Verify the remote endpoints are listed properly
+
+## Security Considerations
+
+- **Private Key**: Never commit the private key to the repository
+- **GitHub Secrets**: Use repository secrets for sensitive information
+- **Key Rotation**: Rotate DNS authentication keys periodically
+- **Access Control**: Limit who can create new releases/tags
+
+## Team Workflow
+
+### For Regular Updates:
+
+1. **Update** `server.json` with new version and any configuration changes
+2. **Test** locally if possible
+3. **Create PR** with changes
+4. **After merge**: Create and push version tag to trigger publishing
+
+### For Emergency Updates:
+
+1. **Make changes** directly to main branch (if needed)
+2. **Immediately tag** and push to trigger emergency publish
+3. **Follow up** with proper documentation and team notification
+
+## Support
+
+For issues with:
+- **MCP Registry**: Check [registry documentation](https://github.com/modelcontextprotocol/registry)
+- **GitHub Actions**: Check workflow logs in Actions tab
+- **Prisma Platform**: Contact platform team for endpoint issues
+- **DNS Configuration**: Contact infrastructure team for DNS changes
+
+---
+
+*Last updated: $(date)*

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,266 +1,83 @@
-# Publishing Prisma Remote MCP Server to Official Registry
+# Publishing Prisma Remote MCP Server
 
-This guide provides step-by-step instructions for publishing the Prisma remote MCP server to the official Model Context Protocol (MCP) registry.
-
-## Overview
-
-This repository contains configuration for publishing Prisma's **remote MCP server** (hosted at `https://mcp.prisma.io/mcp`) to the official MCP registry. This is distinct from the local MCP server that's part of the Prisma ORM NPM package.
-
-### What Gets Published
-
-- **Remote MCP Server**: A cloud-hosted MCP server accessible at `https://mcp.prisma.io/mcp`
-- **Authentication Required**: Requires Bearer token authentication via Prisma platform
-- **Endpoints**: Both SSE (`/sse`) and streamable-http (`/mcp`) protocols supported
+This guide covers publishing Prisma's remote MCP server (hosted at `https://mcp.prisma.io/mcp`) to the official MCP registry.
 
 ## Prerequisites
 
-### 1. DNS Authentication Setup
+**GitHub Secret Required:**
+- `MCP_PUBLISH_PRIVATE_KEY`: DNS authentication private key for `prisma.io` domain
 
-Since we're using the namespace `io.prisma/mcp`, we need DNS authentication for the `prisma.io` domain.
-
-**Required GitHub Secret:**
-- `MCP_PUBLISH_PRIVATE_KEY`: The private key for DNS authentication
-
-### 2. DNS TXT Record
-
-Ensure the following DNS TXT record is configured for `prisma.io`:
-
+**DNS Configuration:**
+Ensure this TXT record exists for `prisma.io`:
 ```
 _mcp-publisher.prisma.io TXT "v=mcp1; pub-key=<PUBLIC_KEY>"
 ```
 
-Where `<PUBLIC_KEY>` is the public key corresponding to the private key stored in GitHub secrets.
-
 ## First-Time Setup
 
-### Step 1: Generate Key Pair (If Not Already Done)
-
-If you need to generate a new key pair for DNS authentication:
-
+**If generating new keys:**
 ```bash
 # Generate private key
 openssl genpkey -algorithm Ed25519 -out private-key.pem
 
-# Extract public key
+# Extract public key for DNS
 openssl pkey -in private-key.pem -pubout -outform DER | base64 -w 0
 ```
 
-### Step 2: Configure DNS Record
+**Configure:**
+1. Add DNS TXT record with public key
+2. Add private key content to GitHub secret `MCP_PUBLISH_PRIVATE_KEY`
 
-Add the TXT record to `prisma.io` DNS configuration:
-
-```
-_mcp-publisher.prisma.io TXT "v=mcp1; pub-key=<BASE64_PUBLIC_KEY>"
-```
-
-### Step 3: Add GitHub Secret
-
-1. Go to the repository settings: `https://github.com/prisma/mcp/settings/secrets/actions`
-2. Click "New repository secret"
-3. Name: `MCP_PUBLISH_PRIVATE_KEY`
-4. Value: The contents of your `private-key.pem` file (including `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----` lines)
-
-## Publishing Process
+## Publishing
 
 ### Automated Publishing (Recommended)
 
-The repository is configured with GitHub Actions for automated publishing:
-
-#### For New Versions:
-
-1. **Update Version**: Update the `version` field in `server.json`
-   ```json
-   {
-     "version": "1.0.1",
-     ...
-   }
-   ```
-
-2. **Commit Changes**:
-   ```bash
-   git add server.json
-   git commit -m "chore: bump version to 1.0.1"
-   git push origin main
-   ```
-
-3. **Create and Push Tag**:
+**For new versions:**
+1. Update `version` in [`server.json`](./server.json)
+2. Commit and push changes
+3. Create and push version tag:
    ```bash
    git tag v1.0.1
    git push origin v1.0.1
    ```
 
-4. **Monitor Workflow**: Check the Actions tab to monitor the publishing process
+**Manual trigger:** Use GitHub Actions UI → "Publish to MCP Registry" → "Run workflow"
 
-#### For Manual Trigger:
-
-You can also trigger publishing manually from the GitHub Actions UI:
-
-1. Go to Actions tab in the repository
-2. Select "Publish to MCP Registry" workflow
-3. Click "Run workflow"
-4. Select the branch and click "Run workflow"
-
-### What the Workflow Does
-
-The automated workflow:
-
-1. ✅ **Validates** `server.json` syntax and structure
-2. 🔍 **Checks** remote endpoint accessibility 
-3. 📦 **Installs** MCP Publisher CLI
-4. 🔐 **Authenticates** using DNS method with private key
-5. 🚀 **Publishes** to the MCP registry
-6. 🧹 **Cleans up** temporary files securely
+### Workflow Process
+1. Validates `server.json` and checks endpoints
+2. Authenticates with DNS method
+3. Publishes to MCP registry
 
 ### Manual Publishing (If Needed)
 
-If you need to publish manually:
+```bash
+# Install MCP Publisher
+curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
-1. **Install MCP Publisher**:
-   ```bash
-   curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
-   ```
-
-2. **Authenticate**:
-   ```bash
-   # Extract private key from GitHub secret or file
-   echo "$MCP_PUBLISH_PRIVATE_KEY" > key.pem
-   
-   # Login using DNS authentication
-   ./mcp-publisher login dns --domain prisma.io --private-key $(openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')
-   ```
-
-3. **Publish**:
-   ```bash
-   ./mcp-publisher publish
-   ```
-
-4. **Clean up**:
-   ```bash
-   rm -f key.pem
-   ```
-
-## Configuration Files
-
-### server.json
-
-The `server.json` file contains the metadata for the remote MCP server:
-
-```json
-{
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
-  "name": "io.prisma/mcp",
-  "description": "MCP server for managing Prisma Postgres.",
-  "version": "1.0.0",
-  "remotes": [
-    {
-      "type": "sse",
-      "url": "https://mcp.prisma.io/sse",
-      "headers": [
-        {
-          "name": "Authorization",
-          "description": "Bearer token for Prisma platform authentication",
-          "isRequired": true,
-          "isSecret": true
-        }
-      ]
-    },
-    {
-      "type": "streamable-http", 
-      "url": "https://mcp.prisma.io/mcp",
-      "headers": [
-        {
-          "name": "Authorization",
-          "description": "Bearer token for Prisma platform authentication", 
-          "isRequired": true,
-          "isSecret": true
-        }
-      ]
-    }
-  ]
-}
+# Authenticate and publish
+echo "$MCP_PUBLISH_PRIVATE_KEY" > key.pem
+./mcp-publisher login dns --domain prisma.io --private-key $(openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')
+./mcp-publisher publish
+rm -f key.pem
 ```
-
-### Key Configuration Points:
-
-- **Namespace**: `io.prisma/mcp` (requires DNS authentication for `prisma.io`)
-- **Remote Endpoints**: Both SSE and streamable-http protocols
-- **Authentication**: Bearer token required for both endpoints
-- **URLs**: Point to the production Prisma platform MCP service
 
 ## Troubleshooting
 
-### Common Issues
+**Authentication failure:** Verify DNS TXT record and key matching
 
-#### 1. Authentication Failure
-```
-Error: DNS authentication failed
-```
-**Solution**: Verify that:
-- The TXT record is properly configured for `_mcp-publisher.prisma.io`
-- The private key in GitHub secrets matches the public key in DNS
-- DNS propagation is complete (may take up to 24 hours)
+**Invalid server.json:** Validate with `python3 -m json.tool server.json`
 
-#### 2. Invalid server.json
-```
-Error: Invalid server configuration
-```
-**Solution**: 
-- Validate JSON syntax using `python3 -m json.tool server.json`
-- Ensure all required fields are present
-- Check that URLs are accessible
+**Endpoint warnings:** Expected for authenticated endpoints
 
-#### 3. Endpoint Validation Warnings
-```
-⚠️ Endpoint may require authentication: https://mcp.prisma.io/mcp
-```
-**This is expected** for authenticated endpoints. The workflow will continue normally.
+**Tag exists:** Use new version or delete existing tag
 
-#### 4. Tag Already Exists
-```
-Error: tag already exists
-```
-**Solution**:
-- Use a new version number
-- Or delete the existing tag: `git tag -d v1.0.1 && git push origin :refs/tags/v1.0.1`
+## Verification
 
-### Verification
-
-After successful publishing, verify your server appears in the registry:
-
-1. Search for "prisma" in the [MCP Registry](https://github.com/modelcontextprotocol/registry)
-2. Check that the server metadata is correct
-3. Verify the remote endpoints are listed properly
-
-## Security Considerations
-
-- **Private Key**: Never commit the private key to the repository
-- **GitHub Secrets**: Use repository secrets for sensitive information
-- **Key Rotation**: Rotate DNS authentication keys periodically
-- **Access Control**: Limit who can create new releases/tags
-
-## Team Workflow
-
-### For Regular Updates:
-
-1. **Update** `server.json` with new version and any configuration changes
-2. **Test** locally if possible
-3. **Create PR** with changes
-4. **After merge**: Create and push version tag to trigger publishing
-
-### For Emergency Updates:
-
-1. **Make changes** directly to main branch (if needed)
-2. **Immediately tag** and push to trigger emergency publish
-3. **Follow up** with proper documentation and team notification
+After publishing, search for "prisma" in the [MCP Registry](https://github.com/modelcontextprotocol/registry) to verify the server appears correctly.
 
 ## Support
 
-For issues with:
-- **MCP Registry**: Check [registry documentation](https://github.com/modelcontextprotocol/registry)
-- **GitHub Actions**: Check workflow logs in Actions tab
-- **Prisma Platform**: Contact platform team for endpoint issues
-- **DNS Configuration**: Contact infrastructure team for DNS changes
-
----
-
-*Last updated: $(date)*
+- **MCP Registry issues:** [Registry docs](https://github.com/modelcontextprotocol/registry)
+- **GitHub Actions:** Check workflow logs
+- **Prisma Platform:** Contact platform team
+- **DNS Configuration:** Contact infrastructure team

--- a/server.json
+++ b/server.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
+  "name": "io.prisma/mcp",
+  "description": "MCP server for Prisma workflows: local migrations, Studio, and hosted Prisma Postgres management.",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/prisma/mcp",
+    "source": "github"
+  },
+  "homepage": "https://www.prisma.io/docs/postgres/integrations/mcp-server",
+  "documentation": "https://www.prisma.io/docs/postgres/integrations/mcp-server",
+  "support": "https://prisma.io/support",
+  "version": "1.0.0",
+  "remotes": [
+    {
+      "type": "sse",
+      "url": "https://mcp.prisma.io/sse"
+    },
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.prisma.io/mcp"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "prisma",
+      "version": "6.16.2",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        { "type": "positional", "value": "mcp" }
+      ]
+    }
+  ],
+  "keywords": ["database", "orm", "prisma", "postgres", "migrations", "schema"],
+  "license": "MIT",
+  "author": {
+    "name": "Prisma",
+    "email": "support@prisma.io",
+    "url": "https://www.prisma.io"
+  }
+}

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json",
   "name": "io.prisma/mcp",
-  "description": "MCP server for Prisma workflows: local migrations, Studio, and hosted Prisma Postgres management.",
+  "description": "MCP server for managing Prisma Postgres.",
   "status": "active",
   "repository": {
     "url": "https://github.com/prisma/mcp",
@@ -14,28 +14,30 @@
   "remotes": [
     {
       "type": "sse",
-      "url": "https://mcp.prisma.io/sse"
+      "url": "https://mcp.prisma.io/sse",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer token for Prisma platform authentication",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
     },
     {
       "type": "streamable-http",
-      "url": "https://mcp.prisma.io/mcp"
-    }
-  ],
-  "packages": [
-    {
-      "registryType": "npm",
-      "registryBaseUrl": "https://registry.npmjs.org",
-      "identifier": "prisma",
-      "version": "6.16.2",
-      "transport": {
-        "type": "stdio"
-      },
-      "packageArguments": [
-        { "type": "positional", "value": "mcp" }
+      "url": "https://mcp.prisma.io/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer token for Prisma platform authentication",
+          "isRequired": true,
+          "isSecret": true
+        }
       ]
     }
   ],
-  "keywords": ["database", "orm", "prisma", "postgres", "migrations", "schema"],
+  "keywords": ["database", "prisma", "postgres"],
   "license": "MIT",
   "author": {
     "name": "Prisma",


### PR DESCRIPTION
**What is this?**
Publishing setup and auto-publishing GH action workflow for https://github.com/modelcontextprotocol/registry

Uses a hybrid server.json for both local and remote (both SSE and streamable HTTP). More docs:
- Local: https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md#constant-fixed-arguments-needed-to-start-the-mcp-server
- Remote: https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md#constant-fixed-arguments-needed-to-start-the-mcp-server
- Hybrid: https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md#server-with-remote-and-package-options

More info:
- https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md#dns-authentication-for-custom-domains
- https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/github-actions.md

**Todo**
- [x] server.json config
- [x] DNS TXT record for login
- [x] GH repo secret for private key
- [x] GH action for publish (that presumably works)
- [ ] Add this to the prisma/prisma package.json: \"mcpName\": \"io.prisma/mcp\"
- [ ] test publishing
- [ ] test GH action auto publishing
- [ ] probably: set up version bumps in this repo for prisma/prisma releases to update server.json and republish with latest ORM version (as version ranges are not accepted for specifying the prisma npm pkg version)

cc @gniting & @rtbenfield 