### PR TITLE
fix: remove unnecessary authentication step

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -52,11 +52,6 @@ jobs:
         env:
           MCP_PUBLISH_PRIVATE_KEY: ${{ secrets.MCP_PUBLISH_PRIVATE_KEY }}
 
-      - name: Login to MCP Registry (GitHub OIDC)
-        if: env.MCP_PUBLISH_PRIVATE_KEY == ''
-        run: ./mcp-publisher login github-oidc
-        env:
-          MCP_PUBLISH_PRIVATE_KEY: ${{ secrets.MCP_PUBLISH_PRIVATE_KEY }}
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish


### PR DESCRIPTION
- Remove GitHub OIDC login step since we're using DNS authentication
- This was causing the publish workflow to fail unnecessarily